### PR TITLE
Hide scrollbar

### DIFF
--- a/js/eventHandle.js
+++ b/js/eventHandle.js
@@ -311,7 +311,7 @@ function CanvasState(canvas) {
             my;
         
         mx = e.clientX - 8;
-        my = e.clientY - y + parseInt($("div#timeAxis").css("bottom"), 10) + parseInt($("canvas").css("height"), 10) + 21;
+        my = e.clientY - y + parseInt($("div#timeAxis").css("bottom"), 10) + parseInt($("canvas").css("height"), 10);
         
         //return location
         return {x: mx, y: my};

--- a/js/interceptWheel.js
+++ b/js/interceptWheel.js
@@ -71,3 +71,27 @@ IGNORE JSLINT WARNINGS FOR THIS SECTION OF CODE.
     }
 
 })(window, document);
+
+window.addEventListener('load', function(){
+ 
+    var startX,
+        startY,
+        dist,
+        elapsedTime,
+        startTime
+ 
+    window.addEventListener('touchstart', function(e){
+        var touchobj = e.changedTouches[0]
+        dist = 0
+        startX = touchobj.pageX
+        startY = touchobj.pageY
+        e.preventDefault()
+    }, false)
+ 
+    window.addEventListener('touchmove', function(e){
+        var touchobj = e.changedTouches[0]
+        dist = touchobj.pageX - startX // get total dist traveled by finger while in contact with surface
+        window.scrollBy(-dist, 0);
+    }, false)
+ 
+}, false);

--- a/js/scroll.js
+++ b/js/scroll.js
@@ -5,11 +5,11 @@ function scroll(event) {
     
     if (shouldScroll) {
         if (event.deltaMode === 0) { // DOM_DELTA_PIXEL
-            window.scrollBy(event.deltaY, 0);
+            window.scrollBy(event.deltaY + event.deltaX, 0);
         } else if (event.deltaMode === 1) { // DOM_DELTA_LINE
-            window.scrollBy(event.deltaY * 30, 0);
+            window.scrollBy((event.deltaY + event.deltaX) * 30, 0);
         } else if (event.deltaMode === 2) { // DOM_DELTA_PAGE
-            window.scrollBy(event.deltaY * 120, 0);
+            window.scrollBy((event.deltaY + event.deltaX) * 120, 0);
         }
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -290,6 +290,7 @@ body {
     color: rgba(256, 256, 256, 1);
     background-color: rgba(64, 64, 64, 1);
     overflow-y: hidden;
+    overflow-x: hidden;
     margin-left: 8px;
 }
 


### PR DESCRIPTION
Seems to be the only workaround for the mac transparent scrollbar with no mouse bug. This is a lack of communication between the browser and the page, which we can do nothing about.